### PR TITLE
Silence matplotlib info logging.

### DIFF
--- a/kedro/config/logging.yml
+++ b/kedro/config/logging.yml
@@ -42,6 +42,11 @@ loggers:
         handlers: [console]
         propagate: no
 
+    matplotlib:
+        level: WARNING
+        handlers: [console]
+        propagate: no
+
 root:
     level: INFO
     handlers: [console, info_file_handler, error_file_handler]


### PR DESCRIPTION
This PR will stop this logging noise:
```
2020-02-26 20:28:04,930 - matplotlib.font_manager - INFO - generated new fontManager
```